### PR TITLE
I22 cache cran db

### DIFF
--- a/R/load_packages.R
+++ b/R/load_packages.R
@@ -1,3 +1,5 @@
+#' @description Read packages from config/packages.csv, filtering to those with valid package names
+#' @return A data.frame with 2 columns: name, url
 get_packages <- function() {
   packages <- read.csv("config/packages.csv",
                        header = FALSE,
@@ -5,6 +7,10 @@ get_packages <- function() {
   packages <- packages[is_valid_name(packages$name),]
 }
 
+#' @description Get CRAN database. Uses cache if available.
+#' @param use_cache Optional Logical. Default TRUE.
+#' @return A data.frame of packages with columns "author","package","title","description","license",
+#' "date/publication","maintainer","reverse_depends"
 get_cran_db <- function(packages, use_cache = TRUE) {
   cran_db <- NULL
   if (use_cache & file.exists("cache/cran_db.rds")) {

--- a/R/load_packages.R
+++ b/R/load_packages.R
@@ -1,0 +1,34 @@
+get_packages <- function() {
+  packages <- read.csv("config/packages.csv",
+                       header = FALSE,
+                       col.names = c("name", "url"))
+  packages <- packages[is_valid_name(packages$name),]
+}
+
+get_cran_db <- function(packages, use_cache = TRUE) {
+  cran_db <- NULL
+  if (use_cache & file.exists("cache/cran_db.rds")) {
+    cached <- readRDS("cache/cran_db.rds")
+    cran_db <- cached$cran_db
+    if (!identical(cached$package_names, packages$name)) {
+      cran_db <- NULL
+    }
+  }
+  if (is.null(cran_db)) {
+    logger::log_info("Package list has changed, or cache not available. Fetching fresh CRAN db.")
+    cran_db <- tools::CRAN_package_db()
+    cran_db <- cran_db[cran_db$Package %in% packages$name,]
+    logger::log_info("Filtering CRAN database")
+    cran_db <- cranly::clean_CRAN_db(cran_db)[, c("author",
+                                                  "package",
+                                                  "title",
+                                                  "description",
+                                                  "license",
+                                                  "date/publication",
+                                                  "maintainer",
+                                                  "reverse_depends")]
+    logger::log_info("Updating cache")
+    saveRDS(list(package_names = packages$name, cran_db = cran_db), "cache/cran_db.rds")
+  }
+  cran_db
+}

--- a/R/load_packages.R
+++ b/R/load_packages.R
@@ -34,6 +34,9 @@ get_cran_db <- function(packages, use_cache = TRUE) {
                                                   "maintainer",
                                                   "reverse_depends")]
     logger::log_info("Updating cache")
+    if (!dir.exists("cache")) {
+      dir.create("cache")
+    }
     saveRDS(list(package_names = packages$name, cran_db = cran_db), "cache/cran_db.rds")
   }
   cran_db

--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ It saves the results in `data/data.csv`.
 
 Note that the Github API is heavily rate-limited if you don't provide a Github PAT. A PAT
 can be provided by setting the environment variable `GITHUB_PAT`.
+
+When you first run the script, the CRAN database is cached in `cache/cran_db.rds`, 
+so subsequent script executions will be quicker. The cache will automatically update if
+the package list changes, but you can also force a cache refresh by deleting the `rds` file.

--- a/scripts/fetch.R
+++ b/scripts/fetch.R
@@ -3,28 +3,7 @@ source("R/utils.R")
 source("R/metadata.R")
 source("R/gh_api.R")
 source("R/fetch_metadata.R")
-
-get_packages <- function() {
-  packages <- read.csv("config/packages.csv",
-                       header = FALSE,
-                       col.names = c("name", "url"))
-  packages <- packages[is_valid_name(packages$name),]
-}
-
-get_cran_db <- function(packages) {
-  logger::log_info("Getting CRAN database")
-  cran_db <- tools::CRAN_package_db()
-  cran_db <- cran_db[cran_db$Package %in% packages$name,]
-  logger::log_info("Filtering CRAN database")
-  cran_db_clean <- cranly::clean_CRAN_db(cran_db)[, c("author",
-                                                      "package",
-                                                      "title",
-                                                      "description",
-                                                      "license",
-                                                      "date/publication",
-                                                      "maintainer",
-                                                      "reverse_depends")]
-}
+source("R/load_packages.R")
 
 packages <- get_packages()
 cran_db <- get_cran_db(packages)


### PR DESCRIPTION
Cache the cran db locally so you can run the `fetch` script multiple times without re-fetching cran each time.

This will hopefully make developing less painful!

Closes #22 
